### PR TITLE
(HC-51) Enable support for using variable substitutions

### DIFF
--- a/dev-resources/puppetlabs/config/file/substitution.conf
+++ b/dev-resources/puppetlabs/config/file/substitution.conf
@@ -1,0 +1,5 @@
+top {
+  henry = text
+  bob = ${top.henry}
+  jim = ${?larry}
+}

--- a/src/puppetlabs/config/typesafe.clj
+++ b/src/puppetlabs/config/typesafe.clj
@@ -81,6 +81,7 @@
   {:pre [(instance? Config config)]
    :post [(map? %)]}
   (-> config
+      .resolve
       .root
       .unwrapped
       nested-java-map->map))

--- a/test/puppetlabs/config/typesafe_test.clj
+++ b/test/puppetlabs/config/typesafe_test.clj
@@ -28,7 +28,13 @@
                     :bam 42
                     :bap {:boozle "boozleboozle"
                           :bip [1 2 {:hi "there"} 3]}}}
+             cfg))))
+  (testing "can parse .conf file with substitution variables"
+    (let [cfg (ts/config-file->map (str test-files-dir "substitution.conf"))]
+      (is (= {:top {:henry "text"
+                    :bob "text"}}
              cfg)))))
+
 
 (deftest reader->map-test
   (testing "can parse .properties stream with nested data structures"
@@ -59,5 +65,13 @@
                     :bam 42
                     :bap {:boozle "boozleboozle"
                           :bip [1 2 {:hi "there"} 3]}}}
+             cfg))))
+  (testing "can parse .conf file with substitution variables"
+    (let [cfg (ts/reader->map
+                (FileInputStream. (str test-files-dir "substitution.conf"))
+                :conf)]
+      (is (= {:top {:henry "text"
+                    :bob "text"}}
              cfg)))))
+
 


### PR DESCRIPTION
HOCON describes rules for variable substitution, but the clojure wrapper
currently does not support them. Specifically use of variables results
in the following exception:

```
com.typesafe.config.ConfigException$NotResolved: need to
Config#resolve(), see the API docs for Config#resolve(); substitution
not resolved: ConfigReference(${henry})
```

This commit fixes that by calling the mentioned resolve method. The
commit also adds tests to cover basic substitution and optional
substitution.