### PR TITLE
Document behavior for non-existing file

### DIFF
--- a/src/puppetlabs/config/typesafe.clj
+++ b/src/puppetlabs/config/typesafe.clj
@@ -91,7 +91,8 @@
 
 (defn config-file->map
   "Given the path to a configuration file (of type .conf, .json, or .properties),
-  parse the file and return a clojure map representation of the data."
+  parse the file and return a clojure map representation of the data.
+  Returns empty map for non-existing file."
   [file-path]
   {:pre [(string? file-path)]
    :post [(map? %)]}

--- a/test/puppetlabs/config/typesafe_test.clj
+++ b/test/puppetlabs/config/typesafe_test.clj
@@ -33,6 +33,10 @@
     (let [cfg (ts/config-file->map (str test-files-dir "substitution.conf"))]
       (is (= {:top {:henry "text"
                     :bob "text"}}
+             cfg))))
+  (testing "returns empty result for non-existing file"
+    (let [cfg (ts/config-file->map (str test-files-dir "non-existing-file.conf"))]
+      (is (= {}
              cfg)))))
 
 


### PR DESCRIPTION
I think it might be misleading for the client of the library to receive empty map when providing non-existing file.

The original typesafe library has an option for this ConfigParseOptions#getAllowMissing options.getAllowMissing() and it is also documented in the method call...