### PR TITLE
(MAINT) Add support for emitting typesafe-config

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.typesafe/config "1.2.0"]]
 
   :plugins [[lein-release "1.0.5"]]

--- a/src/puppetlabs/config/typesafe.clj
+++ b/src/puppetlabs/config/typesafe.clj
@@ -1,8 +1,9 @@
 (ns puppetlabs.config.typesafe
   (:import (java.util Map List)
            (com.typesafe.config ConfigFactory ConfigParseOptions ConfigSyntax
-                                Config))
-  (:require [clojure.java.io :as io]))
+                                Config ConfigValueFactory))
+  (:require [clojure.java.io :as io]
+            [clojure.walk :as walk]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
@@ -123,3 +124,12 @@
          (ConfigFactory/parseReader parse-options)
          config->map))))
 
+(defn map->string
+  "Serialize the clojure data structure `m` to string using the
+  typesafe config format. `m` is typically the result of a
+  `config-file->map` or `reader-map` with some modifications."
+  [m]
+  (-> m
+      walk/stringify-keys
+      ConfigValueFactory/fromAnyRef
+      .render))

--- a/src/puppetlabs/config/typesafe.clj
+++ b/src/puppetlabs/config/typesafe.clj
@@ -13,7 +13,7 @@
 (defn strip-quotes
   "Given a string read from a config file, check to see if it begins and ends with
   double-quotes, and if so, remove them."
-  [s]
+  [^String s]
   {:pre [(string? s)]
    :post [(string? %)
           (not (and (.startsWith % "\"")
@@ -46,7 +46,7 @@
 (defn nested-java-map->map
   "Given a (potentially nested) java Map object read from a config file,
   convert it (potentially recursively) to a clojure map with keywordized keys."
-  [m]
+  [^Map m]
   {:pre [(instance? Map m)]
    :post [(map? %)
           (every? keyword? (keys %))]}
@@ -78,7 +78,7 @@
 
 (defn config->map
   "Converts an instance of `Config` to a more user-friendly clojure map"
-  [config]
+  [^Config config]
   {:pre [(instance? Config config)]
    :post [(map? %)]}
   (-> config

--- a/test/puppetlabs/config/typesafe_test.clj
+++ b/test/puppetlabs/config/typesafe_test.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.config.typesafe_test
-  (:import (java.io FileInputStream))
+  (:import (java.io FileInputStream StringReader))
   (:require [puppetlabs.config.typesafe :as ts]
             [clojure.test :refer :all]))
 
@@ -39,6 +39,14 @@
       (is (= {}
              cfg)))))
 
+(defn round-trip-config
+  "Converts cfg (clojure representation of a config) to a string, then
+  back to clojure data structures"
+  [cfg]
+  (-> cfg
+      ts/map->string
+      StringReader.
+      ts/reader->map))
 
 (deftest reader->map-test
   (testing "can parse .properties stream with nested data structures"
@@ -49,7 +57,8 @@
                     :baz "bazbaz"
                     :bam 42
                     :bap {:boozle "boozleboozle"}}}
-             cfg))))
+             cfg))
+      (is (= cfg (round-trip-config cfg)))))
   (testing "can parse .json stream with nested data structures"
     (let [cfg (ts/reader->map
                 (FileInputStream. (str test-files-dir "config.json"))
@@ -59,7 +68,8 @@
                     :bam 42
                     :bap {:boozle "boozleboozle"
                           :bip [1 2 {:hi "there"} 3]}}}
-             cfg))))
+             cfg))
+      (is (= cfg (round-trip-config cfg)))))
   (testing "can parse .conf stream with nested data structures"
     (let [cfg (ts/reader->map
                 (FileInputStream. (str test-files-dir "config.conf"))
@@ -69,13 +79,13 @@
                     :bam 42
                     :bap {:boozle "boozleboozle"
                           :bip [1 2 {:hi "there"} 3]}}}
-             cfg))))
+             cfg))
+      (is (= cfg (round-trip-config cfg)))))
   (testing "can parse .conf file with substitution variables"
     (let [cfg (ts/reader->map
                 (FileInputStream. (str test-files-dir "substitution.conf"))
                 :conf)]
       (is (= {:top {:henry "text"
                     :bob "text"}}
-             cfg)))))
-
-
+             cfg))
+      (is (= cfg (round-trip-config cfg))))))


### PR DESCRIPTION
This commit adds a function which will convert a clojure data structure to a string using typesafe's config format.