### PR TITLE
(docs) Update README to remove old maintenance/support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,3 @@ A thin clojure wrapper around the [Typesafe Config](https://github.com/typesafeh
 Add the following dependency to your `project.clj` file:
 
 [![Clojars Project](http://clojars.org/puppetlabs/typesafe-config/latest-version.svg)](http://clojars.org/puppetlabs/typesafe-config)
-
-## Support
-
-Please log tickets and issues at our [Jira Tracker](https://tickets.puppetlabs.com/issues/?jql=project%20%3D%20Trapperkeeper).
-
-## Maintenance
-
-Maintainers: Joe Pinsonault <joe.pinsonault@puppet.com>, Chris Price <chris@puppet.com>, Kevin Corcoran <kevin.corcoran@puppet.com>
-
-Tickets: https://tickets.puppetlabs.com/browse/HC


### PR DESCRIPTION
Updates the README to remove old maintainers and drop comments about using JIRA. GitHub Issues should be fine.